### PR TITLE
Adjust margin-top of page and headers

### DIFF
--- a/src/app.scss
+++ b/src/app.scss
@@ -9,7 +9,7 @@ html {
 
 body {
   font-family: sans-serif;
-  margin: 35px;
+  margin: 10px 35px 0px 35px;
   // color: var(--sn-stylekit-editor-foreground-color);
   background-color: transparent;
   font-size: 16px;
@@ -32,5 +32,23 @@ body {
   }
   .gKsMQS li p:first-child {
     word-break: break-word;
+  }
+
+  /* If the first entry in the document is a header, then we want to remove the large header top
+  margin. This is a little tricky, as the first immediate element when that situation occurs
+  is a hidden <a> element. We want to be able to say with css "give me the first adjacent sibling
+  pair of a + h1, but only if it is the very first pair of children under the main panel",
+  but that doesn't seem to be directly possible.
+  https://stackoverflow.com/a/14892952
+
+  We can get a fairly good approximation to just set the margin-top of the second element to 0px.
+  If it is anything other than a header, it has a 0px margin-top anyway.
+   */
+  .gKsMQS {
+    .ProseMirror {
+      :nth-child(2) {
+        margin-top: 0px
+      }
+    }
   }
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1,4 +1,5 @@
 body {
+  /* This margin is overridden (and thus ignored) */
   margin: 0;
   font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen',
     'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue',


### PR DESCRIPTION
The margin-top of the main page is set twice, but one of them (where it is zero) appears to be ignored.
Another one sets it to 35px which seems like too much. This change makes the one that "takes effect" smaller.

Another change is for headers. If a header is a first element, it also gives a large margin at the top. This one
is harder to fix as it needs a css which I don't think is exactly available: "If the first child of the main panel
is an "a" and the second element of this panel is an h1/h2/h3, then make the margin top of that h* to be zero, but leave
all the margin-top settings of all subsequent h* elements". I have gone with a quick fix, which seems like it will work in all cases, though it may now seems slightly closer to the top than is necessary.

This "all works", but if you have a better fix for the desired result, do take over this PR.

# Before:

![image](https://user-images.githubusercontent.com/299102/107128246-24754800-68b4-11eb-83fc-0c5a65917014.png)

# After:

![image](https://user-images.githubusercontent.com/299102/107128236-11fb0e80-68b4-11eb-804e-0fbf3ef257c1.png)

---------------

Here is the "hidden `a` element" before headers:

![image](https://user-images.githubusercontent.com/299102/107128241-1f17fd80-68b4-11eb-818b-c2a009b12ee8.png)
